### PR TITLE
update nvflare version to 2.8

### DIFF
--- a/ai4papi/routers/v1/deployments/tools.py
+++ b/ai4papi/routers/v1/deployments/tools.py
@@ -539,7 +539,7 @@ def create_deployment(
                 "RAM": user_conf["hardware"]["ram"],
                 "DISK": user_conf["hardware"]["disk"],
                 "SHARED_MEMORY": user_conf["hardware"]["ram"] * 10**6 * 0.5,
-                "NVFL_VERSION": "2.5-Stifo",
+                "NVFL_VERSION": "2.8.0",
                 "NVFL_USERNAME": user_conf["nvflare"]["username"],
                 "NVFL_PASSWORD": user_conf["nvflare"]["password"],
                 "NVFL_SERVER1": "%s-server.${meta.domain}-%s" % (job_uuid, base_domain),

--- a/etc/tools/ai4os-nvflare/user.yaml
+++ b/etc/tools/ai4os-nvflare/user.yaml
@@ -33,7 +33,7 @@ nvflare:
 
   app_location:
     name: NVFlare project docker image download link
-    value: 'registry.cloud.ai4eosc.eu/ai4os/ai4os-nvflare-client:2.5-Stifo'
+    value: 'registry.cloud.ai4eosc.eu/ai4os/ai4os-nvflare-client:2.8.0'
     description: NVFlare project docker image download link
 
   public_project:


### PR DESCRIPTION
# Update required for NVFlare 2.8 compatibility

This pull request is related to https://github.com/ai4os/ai4os-nvflare/pull/3 and contains the required changes to support the update of NVFlare to version **2.8.0**.

The changes in this repository are needed to ensure update of nvflare version on the dashboard 

## Related Pull Request

- ai4os/ai4os-nvflare: Update NVFlare to 2.8  
  https://github.com/ai4os/ai4os-nvflare/pull/3

## Changes Made

| File | Change |
|------|--------|
| `ai4papi/routers/v1/deployments/tools.py` (line 542) | Updated `NVFL_VERSION` from `2.5-Stifo` to `2.8.0` |
| `etc/tools/ai4os-nvflare/user.yaml` (line 36) | Updated NVFlare client image from `registry.cloud.ai4eosc.eu/ai4os/ai4os-nvflare-client:2.5-Stifo` to `registry.cloud.ai4eosc.eu/ai4os/ai4os-nvflare-client:2.8.0` |


