### PR TITLE
feat(nvflare): upgrade to v2.8.1

### DIFF
--- a/ai4papi/routers/v1/deployments/tools.py
+++ b/ai4papi/routers/v1/deployments/tools.py
@@ -539,6 +539,7 @@ def create_deployment(
                 "NVFL_VERSION": "2.8.1",
                 "NVFL_USERNAME": user_conf["nvflare"]["username"],
                 "NVFL_PASSWORD": user_conf["nvflare"]["password"],
+                "NVFL_ORGANIZATION": user_conf["nvflare"]["organization"],
                 "NVFL_SERVER1": "%s-server.${meta.domain}-%s" % (job_uuid, base_domain),
                 "NVFL_SHORTNAME": job_uuid[:16],
                 "NVFL_APP_LOCATION": user_conf["nvflare"]["app_location"],

--- a/etc/tools/ai4os-nvflare/nomad.hcl
+++ b/etc/tools/ai4os-nvflare/nomad.hcl
@@ -180,7 +180,7 @@ job "tool-nvflare-${JOB_UUID}" {
       }
 
       env {
-        NVFL_CREDENTIAL="${NVFL_USERNAME}:${NVFL_PASSWORD}"
+        NVFL_CREDENTIAL="${NVFL_USERNAME}:${NVFL_PASSWORD}:${NVFL_ORGANIZATION}"
         NVFL_SERVER1="${NVFL_SERVER1}"
         NVFL_HA_MODE="False"
         NVFL_OVERSEER=""
@@ -220,7 +220,7 @@ job "tool-nvflare-${JOB_UUID}" {
               -L \
               -H 'Content-type: application/json' \
               -d '{"email":"'${NVFL_USERNAME}'", "password": "'${NVFL_PASSWORD}'"}' \
-              ${nvfl_dashboard_url}/api/v1/login \
+              ${nvfl_dashboard_url}/nvflare-dashboard/api/v1/login \
           )
           status=$(jq -r ".status" <<<"$resp")
           if [ "$status" != "ok" ]; then
@@ -241,7 +241,7 @@ job "tool-nvflare-${JOB_UUID}" {
               -H 'Authorization: Bearer '$access_token \
               -H 'Content-type: application/json' \
               -d '{"pin":"'$PIN'"}' \
-              ${nvfl_dashboard_url}/api/v1/servers/1/blob \
+              ${nvfl_dashboard_url}/nvflare-dashboard/api/v1/servers/1/blob \
           )
           filename=$(echo -n "$resp" | sed -En 's/^.+?filename\s+\x27([^\x27]+)\x27.*$/\1/p')
           if [ ! -f $filename ]; then

--- a/etc/tools/ai4os-nvflare/user.yaml
+++ b/etc/tools/ai4os-nvflare/user.yaml
@@ -31,6 +31,11 @@ nvflare:
     value: ''
     description: Admin password for both the Dashboard and the Jupyter server instance.
 
+  organization:
+    name: NVFlare organization
+    value: 'AI4EOSC'
+    description: Name of the organization the admin user belongs to.
+
   app_location:
     name: NVFlare project docker image download link
     value: 'registry.cloud.ai4eosc.eu/ai4os/ai4os-nvflare-client:2.8.1'


### PR DESCRIPTION
Add organization field and fix dashboard API paths

- Add NVFL_ORGANIZATION env var, sourced from a new `organization` field in user.yaml (default: AI4EOSC), and append it to NVFL_CREDENTIAL as username:password:organization
- Prefix NVFlare dashboard API calls with /nvflare-dashboard (login and server blob endpoints)